### PR TITLE
Fix Codecov step by adding the right commit ID, PR number

### DIFF
--- a/template-validate_unittest.yaml
+++ b/template-validate_unittest.yaml
@@ -99,6 +99,11 @@ config:
     -   codecov: |
             if [ "$CODECOV_TOKEN" != "" ]; then
                 $BASE_PYTHON -m pip install codecov .[test]
-                codecov
+                
+                if [ -z $SD_PULL_REQUEST ]; then
+                    codecov -c ${SD_BUILD_SHA} --build ${SD_BUILD_ID}
+                else
+                    codecov --pr ${SD_PULL_REQUEST} -c ${SD_BUILD_SHA} --build ${SD_BUILD_ID}
+                fi
             fi
     -   end: echo "Ending ${SD_TEMPLATE_FULLNAME}"


### PR DESCRIPTION
See https://github.com/screwdriver-cd/python-templates/issues/3. This is the same PR to fix the bug for codecov for the `python` namespace templates